### PR TITLE
BUG: slicer.mrmlScene.GetNodesByClass(..) causes leaks when quitting …

### DIFF
--- a/SlicerDevelopmentToolboxUtils/mixins.py
+++ b/SlicerDevelopmentToolboxUtils/mixins.py
@@ -438,8 +438,7 @@ class ModuleWidgetMixin(GeneralModuleMixin):
     return width
 
   def hideAllSegmentations(self):
-    segmentations = slicer.mrmlScene.GetNodesByClass("vtkMRMLSegmentationNode")
-    for segmentation in [segmentations.GetItemAsObject(idx) for idx in range(0, segmentations.GetNumberOfItems())]:
+    for segmentation in slicer.util.getNodesByClass('vtkMRMLSegmentationNode'):
       segmentation.SetDisplayVisibility(False)
 
 


### PR DESCRIPTION
…Windows

* instead using slicer.util.getNodesByClass('vtkMRMLSegmentationNode')