### PR TITLE
BUG: Qt5 compatibility and slicer.util.getNode regression fix

### DIFF
--- a/SlicerDevelopmentToolboxUtils/helpers.py
+++ b/SlicerDevelopmentToolboxUtils/helpers.py
@@ -4,6 +4,7 @@ import os
 import sys
 import urllib
 from urllib import FancyURLopener
+from packaging import version
 
 import vtk
 import qt
@@ -746,7 +747,9 @@ class SliceAnnotation(object):
     self.textActor.SetDisplayPosition(xPos, yPos)
 
   def _applyHorizontalAlign(self):
-    centerX = int((self.sliceView.width - self._getFontWidth()) / 2)
+    sliceViewWidth = self.sliceView.width if version.parse(qt.Qt.qVersion()) < version.parse("5.0.0") else \
+      self.sliceView.width * self.sliceView.devicePixelRatio()
+    centerX = int((sliceViewWidth - self._getFontWidth()) / 2)
     if self.xPos:
       xPos = self.xPos if 0 < self.xPos < centerX else centerX
     else:
@@ -755,16 +758,18 @@ class SliceAnnotation(object):
       elif self.horizontalAlign == self.ALIGN_CENTER:
         xPos = centerX
       elif self.horizontalAlign == self.ALIGN_RIGHT:
-        xPos = self.sliceView.width - self._getFontWidth()
+        xPos = sliceViewWidth - self._getFontWidth()
     return int(xPos)
 
   def _applyVerticalAlign(self):
-    centerY = int((self.sliceView.height - self._getFontHeight()) / 2)
+    sliceViewHeight = self.sliceView.height if version.parse(qt.Qt.qVersion()) < version.parse("5.0.0") else \
+      self.sliceView.height * self.sliceView.devicePixelRatio()
+    centerY = int((sliceViewHeight - self._getFontHeight()) / 2)
     if self.yPos:
       yPos = self.yPos if 0 < self.yPos < centerY else centerY
     else:
       if self.verticalAlign == self.ALIGN_TOP:
-        yPos = self.sliceView.height - self._getFontHeight()
+        yPos = sliceViewHeight - self._getFontHeight()
       elif self.verticalAlign == self.ALIGN_CENTER:
         yPos = centerY
       elif self.verticalAlign == self.ALIGN_BOTTOM:
@@ -795,7 +800,8 @@ class SliceAnnotation(object):
     tempSize = self.textProperty.GetFontSize()
     self.textProperty.SetFontSize(size)
     self.textActor.SetTextProperty(self.textProperty)
-    if self._getFontWidth() > self.sliceView.width:
+    if self._getFontWidth() > (self.sliceView.width if version.parse(qt.Qt.qVersion()) < version.parse("5.0.0") else \
+            self.sliceView.width * self.sliceView.devicePixelRatio()):
       self.textProperty.SetFontSize(tempSize)
       self.textActor.SetTextProperty(self.textProperty)
       return False

--- a/SlicerDevelopmentToolboxUtils/widgets.py
+++ b/SlicerDevelopmentToolboxUtils/widgets.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 import xml.dom
+from packaging import version
 
 import ctk
 import qt
@@ -265,9 +266,12 @@ class TargetCreationWidget(qt.QWidget, ModuleWidgetMixin):
     self.table.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
     self.table.setSelectionMode(qt.QAbstractItemView.SingleSelection)
     self.table.setMaximumHeight(200)
-    self.table.horizontalHeader().setResizeMode(qt.QHeaderView.Stretch)
-    self.table.horizontalHeader().setResizeMode(0, qt.QHeaderView.Stretch)
-    self.table.horizontalHeader().setResizeMode(1, qt.QHeaderView.ResizeToContents)
+    method = getattr(self.table.horizontalHeader(),
+                     "setResizeMode" if version.parse(qt.Qt.qVersion()) < version.parse("5.0.0") else
+                     "setSectionResizeMode")
+    method(qt.QHeaderView.Stretch)
+    method(0, qt.QHeaderView.Stretch)
+    method(1, qt.QHeaderView.ResizeToContents)
     self._resetTable()
     self.layout().addWidget(self.table)
 

--- a/SlicerDevelopmentToolboxUtils/widgets.py
+++ b/SlicerDevelopmentToolboxUtils/widgets.py
@@ -1774,9 +1774,11 @@ class SliceWidgetDialogBase(qt.QDialog, ModuleWidgetMixin):
     self.buttonBox.clicked.connect(lambda b: setattr(self, "clickedButton", self.buttonBox.standardButton(b)))
 
   def setupSliceWidget(self):
-    black = slicer.util.getNode('Black')
-    if black:
+    try:
+      black = slicer.util.getNode('Black')
       slicer.mrmlScene.RemoveNode(black)
+    except slicer.util.MRMLNodeNotFoundException:
+      pass
     self.sliceNode = slicer.vtkMRMLSliceNode()
     self.sliceNode.SetName("Black")
     self.sliceNode.SetLayoutName("Black")


### PR DESCRIPTION
The following addressed:
* Qt5 compatibility for setResizeMode method -> setSectionResize
* Handle Qt5 introduction of devicePixelRatio for high DPI display support
* Catch new exception introduced by slicer.util.getNode() core changes