### PR TITLE
COMP: retrieve DICOM values of scalar volume node

### DIFF
--- a/SlicerDevelopmentToolboxUtils/mixins.py
+++ b/SlicerDevelopmentToolboxUtils/mixins.py
@@ -717,7 +717,7 @@ class ModuleLogicMixin(GeneralModuleMixin):
       elif type(inputArg) is str and os.path.isfile(inputArg):
         value = slicer.dicomDatabase.fileValue(inputArg, tagName)
       elif type(inputArg) is slicer.vtkMRMLScalarVolumeNode:
-        f = inputArg.GetStorageNode().GetFileName()
+        f = slicer.dicomDatabase.fileForInstance(inputArg.GetAttribute("DICOM.instanceUIDs").split(" ")[0])
         value = slicer.dicomDatabase.fileValue(f, tagName)
       elif type(inputArg) is slicer.vtkMRMLMultiVolumeNode:
         f = slicer.dicomDatabase.fileForInstance(inputArg.GetAttribute("DICOM.instanceUIDs").split(" ")[0])


### PR DESCRIPTION
Scalar volume nodes loaded from DICOM files no longer have a storage node assigned, depending on the chosen DICOM reader. The volume's filename can instead be obtained from a lookup in the DICOM database.