### PR TITLE
COMP: Update according to vtkMRMLSliceLogic API changes

### DIFF
--- a/SlicerDevelopmentToolboxUtils/mixins.py
+++ b/SlicerDevelopmentToolboxUtils/mixins.py
@@ -307,7 +307,7 @@ class ModuleWidgetMixin(GeneralModuleMixin, UICreationHelpers):
     sliceLogics = lm.mrmlSliceLogics()
     for n in range(sliceLogics.GetNumberOfItems()):
       sliceLogic = sliceLogics.GetItemAsObject(n)
-      widget = lm.sliceWidget(sliceLogic.GetName())
+      widget = lm.sliceWidget(sliceLogic.GetSliceNode().GetName())
       if widget.sliceView().visible:
          yield widget
 


### PR DESCRIPTION
vtkMRMLSliceLogic's Set/GetName were replace by AddSliceNode(const char* layoutName) and GetSliceNode.GetName()
in https://github.com/Slicer/Slicer/commit/e78f557cd0cc70587e6dc01fa4983447462b0db6